### PR TITLE
DD-1036 Upgrade DropWizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>dans-dropwizard-project</artifactId>
         <groupId>nl.knaw.dans.shared</groupId>
-        <version>7.2.0</version>
+        <version>7.4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans</groupId>
@@ -52,17 +52,14 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-java-utils</artifactId>
-            <version>0.0.1</version>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>0.1.0</version>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard.modules</groupId>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-health</artifactId>
-            <version>1.7.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,6 @@
             <artifactId>dans-dataverse-client-lib</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-health</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -80,12 +76,6 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <artifactId>dans-dropwizard-project</artifactId>
         <groupId>nl.knaw.dans.shared</groupId>
-        <version>7.4.0-SNAPSHOT</version>
+        <version>7.4.0</version>
     </parent>
 
     <groupId>nl.knaw.dans</groupId>
     <artifactId>dd-workflow-step-virus-scan</artifactId>
     <version>0.2.1-SNAPSHOT</version>
 
-    <name>Dd Workflow Step Virus Scan</name>
+    <name>DD Workflow Step Virus Scan</name>
     <url>https://github.com/DANS-KNAW/dd-workflow-step-virus-scan</url>
     <description>Workflow step for scanning datasets for virus before publication</description>
     <inceptionYear>2022</inceptionYear>

--- a/src/main/java/nl/knaw/dans/virusscan/DdWorkflowStepVirusScanApplication.java
+++ b/src/main/java/nl/knaw/dans/virusscan/DdWorkflowStepVirusScanApplication.java
@@ -19,13 +19,13 @@ package nl.knaw.dans.virusscan;
 import io.dropwizard.Application;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.setup.Environment;
-import nl.knaw.dans.virusscan.health.ClamdHealthCheck;
-import nl.knaw.dans.virusscan.health.DataverseHealthCheck;
 import nl.knaw.dans.virusscan.core.service.ClamdServiceImpl;
 import nl.knaw.dans.virusscan.core.service.DatasetResumeTaskFactoryImpl;
 import nl.knaw.dans.virusscan.core.service.DatasetScanTaskFactoryImpl;
 import nl.knaw.dans.virusscan.core.service.DataverseApiServiceImpl;
 import nl.knaw.dans.virusscan.core.service.VirusScannerImpl;
+import nl.knaw.dans.virusscan.health.ClamdHealthCheck;
+import nl.knaw.dans.virusscan.health.DataverseHealthCheck;
 import nl.knaw.dans.virusscan.resource.InvokeResourceImpl;
 
 public class DdWorkflowStepVirusScanApplication extends Application<DdWorkflowStepVirusScanConfiguration> {

--- a/src/main/java/nl/knaw/dans/virusscan/DdWorkflowStepVirusScanApplication.java
+++ b/src/main/java/nl/knaw/dans/virusscan/DdWorkflowStepVirusScanApplication.java
@@ -18,12 +18,9 @@ package nl.knaw.dans.virusscan;
 
 import io.dropwizard.Application;
 import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.health.conf.HealthConfiguration;
-import io.dropwizard.health.core.HealthCheckBundle;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import nl.knaw.dans.virusscan.core.health.ClamdHealthCheck;
-import nl.knaw.dans.virusscan.core.health.DataverseHealthCheck;
+import nl.knaw.dans.virusscan.health.ClamdHealthCheck;
+import nl.knaw.dans.virusscan.health.DataverseHealthCheck;
 import nl.knaw.dans.virusscan.core.service.ClamdServiceImpl;
 import nl.knaw.dans.virusscan.core.service.DatasetResumeTaskFactoryImpl;
 import nl.knaw.dans.virusscan.core.service.DatasetScanTaskFactoryImpl;
@@ -40,17 +37,6 @@ public class DdWorkflowStepVirusScanApplication extends Application<DdWorkflowSt
     @Override
     public String getName() {
         return "Dd Workflow Step Virus Scan";
-    }
-
-    @Override
-    public void initialize(final Bootstrap<DdWorkflowStepVirusScanConfiguration> bootstrap) {
-        bootstrap.addBundle(new HealthCheckBundle<>() {
-
-            @Override
-            protected HealthConfiguration getHealthConfiguration(final DdWorkflowStepVirusScanConfiguration configuration) {
-                return configuration.getHealthConfiguration();
-            }
-        });
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/virusscan/DdWorkflowStepVirusScanConfiguration.java
+++ b/src/main/java/nl/knaw/dans/virusscan/DdWorkflowStepVirusScanConfiguration.java
@@ -19,7 +19,6 @@ package nl.knaw.dans.virusscan;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
-import io.dropwizard.health.HealthCheckConfiguration;
 import nl.knaw.dans.virusscan.core.config.DataverseConfig;
 import nl.knaw.dans.virusscan.core.config.VirusScannerConfig;
 
@@ -38,18 +37,6 @@ public class DdWorkflowStepVirusScanConfiguration extends Configuration {
     @Valid
     @NotNull
     private VirusScannerConfig virusscanner;
-    @Valid
-    @NotNull
-    @JsonProperty("health")
-    private HealthCheckConfiguration healthConfiguration;
-
-    public HealthCheckConfiguration getHealthConfiguration() {
-        return healthConfiguration;
-    }
-
-    public void setHealthConfiguration(HealthCheckConfiguration healthConfiguration) {
-        this.healthConfiguration = healthConfiguration;
-    }
 
     public JerseyClientConfiguration getJerseyClient() {
         return jerseyClient;

--- a/src/main/java/nl/knaw/dans/virusscan/DdWorkflowStepVirusScanConfiguration.java
+++ b/src/main/java/nl/knaw/dans/virusscan/DdWorkflowStepVirusScanConfiguration.java
@@ -19,7 +19,7 @@ package nl.knaw.dans.virusscan;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
-import io.dropwizard.health.conf.HealthConfiguration;
+import io.dropwizard.health.HealthCheckConfiguration;
 import nl.knaw.dans.virusscan.core.config.DataverseConfig;
 import nl.knaw.dans.virusscan.core.config.VirusScannerConfig;
 
@@ -41,13 +41,13 @@ public class DdWorkflowStepVirusScanConfiguration extends Configuration {
     @Valid
     @NotNull
     @JsonProperty("health")
-    private HealthConfiguration healthConfiguration = new HealthConfiguration();
+    private HealthCheckConfiguration healthConfiguration;
 
-    public HealthConfiguration getHealthConfiguration() {
+    public HealthCheckConfiguration getHealthConfiguration() {
         return healthConfiguration;
     }
 
-    public void setHealthConfiguration(HealthConfiguration healthConfiguration) {
+    public void setHealthConfiguration(HealthCheckConfiguration healthConfiguration) {
         this.healthConfiguration = healthConfiguration;
     }
 

--- a/src/main/java/nl/knaw/dans/virusscan/health/ClamdHealthCheck.java
+++ b/src/main/java/nl/knaw/dans/virusscan/health/ClamdHealthCheck.java
@@ -13,37 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.virusscan.core.health;
+package nl.knaw.dans.virusscan.health;
 
 import com.codahale.metrics.health.HealthCheck;
-import nl.knaw.dans.virusscan.core.service.DataverseApiService;
+import nl.knaw.dans.virusscan.core.service.ClamdService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-public class DataverseHealthCheck extends HealthCheck {
-    private static final Logger log = LoggerFactory.getLogger(DataverseHealthCheck.class);
+public class ClamdHealthCheck extends HealthCheck {
+    private static final Logger log = LoggerFactory.getLogger(ClamdHealthCheck.class);
 
-    private final DataverseApiService dataverseApiService;
+    private final ClamdService clamdService;
 
-    public DataverseHealthCheck(DataverseApiService dataverseApiService) {
-        this.dataverseApiService = dataverseApiService;
+    public ClamdHealthCheck(ClamdService clamdService) {
+        this.clamdService = clamdService;
     }
 
     @Override
     protected Result check() {
         try {
-            var info = dataverseApiService.getDataverseInfo();
+            var result = clamdService.ping();
+            log.trace("Result from ClamAV PING request: {}", result);
 
-            if (info.getStatus().equalsIgnoreCase("OK")) {
+            if ("PONG\n".equalsIgnoreCase(result)) {
                 return Result.healthy();
             }
             else {
-                throw new IOException(String.format("Version request returned incorrect status '%s'", info.getStatus()));
+                throw new IOException(String.format("Unexpected output from ClamAV: %s", result));
             }
         }
         catch (IOException e) {
+            log.error("IO error occurred while communicating with ClamAV", e);
             return Result.builder()
                 .withMessage(e.getMessage())
                 .unhealthy(e)

--- a/src/test/java/nl/knaw/dans/virusscan/core/config/validation/ValidClamdBufferSizeValidatorTest.java
+++ b/src/test/java/nl/knaw/dans/virusscan/core/config/validation/ValidClamdBufferSizeValidatorTest.java
@@ -18,7 +18,8 @@ package nl.knaw.dans.virusscan.core.config.validation;
 import nl.knaw.dans.virusscan.core.config.ClamdConfig;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ValidClamdBufferSizeValidatorTest {
 

--- a/src/test/java/nl/knaw/dans/virusscan/core/service/DatasetResumeTaskFactoryImplTest.java
+++ b/src/test/java/nl/knaw/dans/virusscan/core/service/DatasetResumeTaskFactoryImplTest.java
@@ -17,15 +17,11 @@ package nl.knaw.dans.virusscan.core.service;
 
 import nl.knaw.dans.virusscan.core.config.ResumeTasksConfig;
 import nl.knaw.dans.virusscan.core.model.DatasetResumeTaskPayload;
-import nl.knaw.dans.virusscan.core.model.PrePublishWorkflowPayload;
 import nl.knaw.dans.virusscan.core.task.DatasetResumeTask;
-import nl.knaw.dans.virusscan.core.task.DatasetScanTask;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.concurrent.ExecutorService;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class DatasetResumeTaskFactoryImplTest {
 

--- a/src/test/java/nl/knaw/dans/virusscan/health/ClamdHealthCheckTest.java
+++ b/src/test/java/nl/knaw/dans/virusscan/health/ClamdHealthCheckTest.java
@@ -16,7 +16,6 @@
 package nl.knaw.dans.virusscan.health;
 
 import nl.knaw.dans.virusscan.core.service.ClamdService;
-import nl.knaw.dans.virusscan.health.ClamdHealthCheck;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/src/test/java/nl/knaw/dans/virusscan/health/ClamdHealthCheckTest.java
+++ b/src/test/java/nl/knaw/dans/virusscan/health/ClamdHealthCheckTest.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.virusscan.core.health;
+package nl.knaw.dans.virusscan.health;
 
 import nl.knaw.dans.virusscan.core.service.ClamdService;
+import nl.knaw.dans.virusscan.health.ClamdHealthCheck;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/src/test/java/nl/knaw/dans/virusscan/health/DataverseHealthCheckTest.java
+++ b/src/test/java/nl/knaw/dans/virusscan/health/DataverseHealthCheckTest.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.virusscan.core.health;
+package nl.knaw.dans.virusscan.health;
 
 import nl.knaw.dans.virusscan.core.model.DataverseVersionResponse;
 import nl.knaw.dans.virusscan.core.service.DataverseApiService;
+import nl.knaw.dans.virusscan.health.DataverseHealthCheck;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/src/test/java/nl/knaw/dans/virusscan/health/DataverseHealthCheckTest.java
+++ b/src/test/java/nl/knaw/dans/virusscan/health/DataverseHealthCheckTest.java
@@ -17,7 +17,6 @@ package nl.knaw.dans.virusscan.health;
 
 import nl.knaw.dans.virusscan.core.model.DataverseVersionResponse;
 import nl.knaw.dans.virusscan.core.service.DataverseApiService;
-import nl.knaw.dans.virusscan.health.DataverseHealthCheck;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/src/test/java/nl/knaw/dans/virusscan/resource/InvokeResourceImplTest.java
+++ b/src/test/java/nl/knaw/dans/virusscan/resource/InvokeResourceImplTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 class InvokeResourceImplTest {


### PR DESCRIPTION
Fixes DD-1036

# Description of changes
* Upgraded to parent pom 7.4.0 and to DropWizard 2.1.1
* Moved the health checks to the standard location
* Changed dependency to `io.dropwizard.modules:dropwizard-health` to `io.dropwizard:dropwizard-health` (no `modules`) and made necessary code changes.


# Notify
@DANS-KNAW/dataversedans
